### PR TITLE
Hardcode github raw link to image

### DIFF
--- a/notebooks/How_to_Generate_Earthdata_Prerequisite_Files.ipynb
+++ b/notebooks/How_to_Generate_Earthdata_Prerequisite_Files.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "### Example\n",
     "\n",
-    "<img src=\"../images/Prerequisite-Files-Diagram.png\" alt=\"Prerequisite Files Diagram\">\n",
+    "<img src=\"https://raw.githubusercontent.com/nasa/gesdisc-tutorials/main/images/Prerequisite-Files-Diagram.png\" alt=\"Prerequisite Files Diagram\">\n",
     "\n",
     "Figure 1: File and folder hierarchy showing where each Earthdata authentication file should be stored in your local filesystem.\n",
     "\n",


### PR DESCRIPTION
Changed image link in introduction markdown to be a hardcoded URL to the raw Github image. This should fix the image not being correctly rendered in the how-to nbviewer: https://disc.gsfc.nasa.gov/information/howto?keywords=prerequisite&title=How%20to%20Generate%20Earthdata%20Prerequisite%20Files