### PR TITLE
Update ArcGIS Notebook to use Cloud Link

### DIFF
--- a/notebooks/How_to_Find_the_Max_Precipitation_Value_of_a_ROI_Using_an_ArcGIS_Image_Service.ipynb
+++ b/notebooks/How_to_Find_the_Max_Precipitation_Value_of_a_ROI_Using_an_ArcGIS_Image_Service.ipynb
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "id": "nfIGhUjZH9uG"
    },
@@ -166,7 +166,7 @@
    ],
    "source": [
     "#Define data source (NASA GPM IMERGHHE Imagery Service)\n",
-    "data = ImageryLayer('https://arcgis.gesdisc.eosdis.nasa.gov/authoritative/rest/services/GPM_3IMERGHHE_06/ImageServer')\n",
+    "data = ImageryLayer('https://gis.earthdata.nasa.gov/image/rest/services/GESDISC/GPM_3IMERGHHE/ImageServer')\n",
     "\n",
     "#Define lists and time ranges\n",
     "time_range = []\n",


### PR DESCRIPTION
Remove on-prem link from the bottom cell and replace with Cloud ArcGIS server link.